### PR TITLE
Add utf16 support

### DIFF
--- a/README
+++ b/README
@@ -24,7 +24,6 @@ State:
 
 Missing features:
 
- * Correct handling and tests for surrogate pairs
  * Detection of cycles in input data structures (might never be fixed)
 
 Credits

--- a/lib/JSON/Tiny.pm
+++ b/lib/JSON/Tiny.pm
@@ -26,7 +26,9 @@ multi to-json(Str:D  $d) {
     '"'
     ~ $d.trans(['"',  '\\',   "\b", "\f", "\n", "\r", "\t"]
             => ['\"', '\\\\', '\b', '\f', '\n', '\r', '\t'])\
-            .subst(/<-[\c32..\c126]>/, { ord(~$_).fmt('\u%04x') }, :g)
+            .subst(/<-[\c32..\c126]>/, {
+                $_.Str.encode('utf-16').values».fmt('\u%04x').join
+            }, :g)
     ~ '"'
 }
 multi to-json(Positional:D $d) {

--- a/lib/JSON/Tiny/Actions.pm
+++ b/lib/JSON/Tiny/Actions.pm
@@ -39,9 +39,8 @@ method value:sym<array>($/)  { make $<array>.ast }
 method str($/)               { make ~$/ }
 
 method str_escape($/) {
-    if $<xdigit> {
-        # make chr(:16($<xdigit>.join));  # preferred version of next line, but it doesn't work on Niecza yet
-        make chr(eval "0x" ~ $<xdigit>.join);
+    if $<utf16_codepoint> {
+        make utf16.new( $<utf16_codepoint>.map('0x'~*)».Int ).decode();
     } else {
         my %h = '\\' => "\\",
                 '/'  => "/",

--- a/lib/JSON/Tiny/Grammar.pm
+++ b/lib/JSON/Tiny/Grammar.pm
@@ -31,7 +31,11 @@ token str {
 }
 
 token str_escape {
-    <["\\/bfnrt]> | u <xdigit>**4
+    <["\\/bfnrt]> | 'u' <utf16_codepoint>+ % '\u'
+}
+
+token utf16_codepoint {
+    <.xdigit>**4
 }
 
 # vim: ft=perl6

--- a/t/05-utf16.t
+++ b/t/05-utf16.t
@@ -1,0 +1,22 @@
+use v6;
+BEGIN { @*INC.push('lib') };
+
+use JSON::Tiny;
+use Test;
+
+plan 2;
+
+# U+1D4B7 MATHEMATICAL SCRIPT SMALL B, from the WHATWG HTML entities JSON file
+my $surrogate-pair = '\uD835\uDCB7';
+my $json = '{ "codepoints" :  [119991], "characters" :  "\uD835\uDCB7" }';
+my $perl =  { 'codepoints' => [119991], 'characters' => '𝒷'            };
+
+my $parsed = from-json($json);
+
+is_deeply $parsed, $perl,
+    "UTF-16 surrogate pair «$surrogate-pair» parses correctly";
+
+my $serialised = to-json($parsed<characters>);
+
+is $serialised.lc, '"' ~ $surrogate-pair.lc ~ '"',
+    'Astral plane codepoint roundtrips back to original JSON string';


### PR DESCRIPTION
Here's my attempt at getting surrogate pairs working.

It comes with one small caveat: this doesn't work in any current implementation. Rakudo broke after perl6/nqp@360e781 (according to git-bisect), and Niecza's Buf support is incomplete.

Apart from that, I've double-checked this code a few times and it looks correct.