### PR TITLE
return Any for an empty string

### DIFF
--- a/lib/JSON/Tiny.pm
+++ b/lib/JSON/Tiny.pm
@@ -46,6 +46,7 @@ multi to-json(Mu:D $s) {
 }
 
 sub from-json($text) is export {
+    return Any unless $text;
     my $a = JSON::Tiny::Actions.new();
     my $o = JSON::Tiny::Grammar.parse($text, :actions($a));
     return $o.ast;


### PR DESCRIPTION
Otherwise we would get: No such method 'ast' for invocant of type 'Any'
This unbreaks JSON::RPC
