### PR TITLE
Add unit declarator to module, class and grammar declarations

### DIFF
--- a/lib/JSON/Tiny.pm
+++ b/lib/JSON/Tiny.pm
@@ -13,7 +13,7 @@ It supports strings, numbers, arrays and hashes (no custom objects).
 
 =end pod
 
-module JSON::Tiny;
+unit module JSON::Tiny;
 
 use JSON::Tiny::Actions;
 use JSON::Tiny::Grammar;

--- a/lib/JSON/Tiny/Actions.pm
+++ b/lib/JSON/Tiny/Actions.pm
@@ -1,4 +1,4 @@
-class JSON::Tiny::Actions;
+unit class JSON::Tiny::Actions;
 
 method TOP($/) {
     make $/.values.[0].made;

--- a/lib/JSON/Tiny/Grammar.pm
+++ b/lib/JSON/Tiny/Grammar.pm
@@ -1,5 +1,5 @@
 use v6;
-grammar JSON::Tiny::Grammar;
+unit grammar JSON::Tiny::Grammar;
 
 token TOP       { ^ \s* [ <object> | <array> ] \s* $ }
 rule object     { '{' ~ '}' <pairlist>     }


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.